### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,8 +18,8 @@
 
 # Security-sensitive
 /.github/workflows/security/        @jclee941
-/.github/workflows/codeql.yml       @jclee941
-/.github/workflows/gitleaks.yml     @jclee941
+/.github/workflows/06_codeql.yml    @jclee941
+/.github/workflows/05_gitleaks.yml  @jclee941
 /.github/CODEOWNERS                 @jclee941
 
 # Docs / templates

--- a/.github/workflows/08_scorecard.yml
+++ b/.github/workflows/08_scorecard.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -44,13 +44,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: Scorecard analysis
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/09_semantic-pr.yml
+++ b/.github/workflows/09_semantic-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   semantic-pr:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - name: Harden Runner

--- a/.github/workflows/10_pr-review.yml
+++ b/.github/workflows/10_pr-review.yml
@@ -21,7 +21,7 @@ jobs:
   pr_review:
     strategy:
       matrix:
-        model: [kimi-k2.6, minimax-m2.7, gpt-5.5]
+        model: [minimax-m2.7, gpt-5.5]
       fail-fast: false
     concurrency:
       group: pr-review-${{ github.event.pull_request.number }}-${{ matrix.model }}
@@ -36,6 +36,12 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
+      - name: Checkout local actions
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          fetch-depth: 1
       - name: Check out pr-agent source from jclee941/.github
         uses: actions/checkout@v6
         with:
@@ -118,10 +124,10 @@ jobs:
           LITELLM_LOCAL_MODEL_COST_MAP: "True"
           PR_REVIEW_DEBUG: ${{ vars.PR_REVIEW_DEBUG || '0' }}
           CONFIG__MODEL: ${{ matrix.model }}
-          # Canonical fallback chain (matches .pr_agent.toml, 40_repo-review-batch,
-          # 86_pr-review-security, configuration.toml). litellm skips the matrix.model
-          # if it already failed as primary, so listing it here is harmless.
-          CONFIG__FALLBACK_MODELS: '["kimi-k2.5", "minimax-m2.7"]'
+          # Canonical fallback chain (matches .pr_agent.toml + configuration.toml +
+          # all review workflows; enforced by 90_sanity.yml). litellm skips the
+          # matrix.model if it already failed as primary, so listing it is harmless.
+          CONFIG__FALLBACK_MODELS: '["minimax-m2.7", "gpt-5.5"]'
           CONFIG__RESPONSE_LANGUAGE: ko
           CONFIG__AI_TIMEOUT: "180"
           CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
@@ -231,25 +237,6 @@ jobs:
           .venv/bin/python scripts/pr_review_runner.py "$PR_URL"
       - name: Notify on failure
         if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NOTIFY_TITLE: 'PR Review failed for PR #${{ github.event.pull_request.number }}'
-        run: |
-          set -eu
-          SHORT_SHA="${GITHUB_SHA:0:8}"
-          TITLE="${NOTIFY_TITLE:-[ci-fail] $GITHUB_WORKFLOW @ $SHORT_SHA}"
-          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-            --state open --label ci-failure \
-            --json number,title \
-            --jq ".[] | select(.title == \"$TITLE\") | .number" 2>/dev/null | head -1 || true)
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-              --body "Another failure: $RUN_URL" || true
-          else
-            gh label create ci-failure --color B60205 2>/dev/null || true
-            gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "$TITLE" \
-              --body "$GITHUB_WORKFLOW workflow failed on \`$GITHUB_SHA\`. See [run logs]($RUN_URL)." \
-              --label ci-failure || true
-          fi
+        uses: ./.github/actions/notify-on-failure
+        with:
+          title: 'PR Review failed for PR #${{ github.event.pull_request.number }}'

--- a/.github/workflows/12_dependabot-auto-merge.yml
+++ b/.github/workflows/12_dependabot-auto-merge.yml
@@ -119,6 +119,35 @@ jobs:
           echo "::error::failed to enable auto-merge for $PR_URL"
           exit "$status"
 
+      - name: Self-heal stale BLOCKED PR
+        # When auto-merge is enabled and all checks pass but GitHub still
+        # reports mergeStateStatus=BLOCKED, the PR's base is stale: it was
+        # opened against an older default-branch tip whose workflows produced
+        # a now-renamed required check (e.g. bare 'scan' vs 'Gitleaks / scan').
+        # Updating the branch re-runs current workflows and clears the block.
+        # We never use --admin; branch protection is still enforced.
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          state="$(gh pr view "$PR_URL" --json mergeStateStatus,statusCheckRollup \
+            --jq '.mergeStateStatus')"
+          failed="$(gh pr view "$PR_URL" --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]? | select((.conclusion // .state) == "FAILURE")] | length')"
+          if [[ "$state" == "BLOCKED" && "$failed" == "0" ]]; then
+            echo "::notice::PR $PR_URL is BLOCKED with no failing checks; updating branch to clear stale required-context drift"
+            # gh CLI on the runner may predate the `gh pr update-branch`
+            # subcommand, so call the REST endpoint directly.
+            gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
+              || echo "::warning::update-branch failed (already up to date, conflict, or not permitted); not retrying"
+          else
+            echo "::notice::PR $PR_URL mergeStateStatus=$state failed=$failed; no self-heal needed"
+          fi
+
       - name: Flag major updates for manual review
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
         env:

--- a/.github/workflows/13_pr-auto-merge.yml
+++ b/.github/workflows/13_pr-auto-merge.yml
@@ -121,6 +121,32 @@ jobs:
           # and the merge box is green. We just enable it; we never bypass.
           gh pr merge --auto --squash "$PR_URL" \
             || echo "::warning::auto-merge enable failed (allow_auto_merge disabled, branch protection mismatch, or PR already merged); not retrying"
+
+      - name: Self-heal stale BLOCKED PR
+        # If checks pass but GitHub reports mergeStateStatus=BLOCKED, the PR's
+        # base is stale (older default-branch tip produced a now-renamed
+        # required check, e.g. bare 'scan' vs 'Gitleaks / scan'). Update the
+        # branch to re-run current workflows and clear the block. Never --admin.
+        if: env.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          state="$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')"
+          failed="$(gh pr view "$PR_URL" --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]? | select((.conclusion // .state) == "FAILURE")] | length')"
+          if [ "$state" = "BLOCKED" ] && [ "$failed" = "0" ]; then
+            echo "::notice::PR $PR_URL is BLOCKED with no failing checks; updating branch to clear stale required-context drift"
+            # gh CLI on the runner may predate the `gh pr update-branch`
+            # subcommand, so call the REST endpoint directly.
+            gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
+              || echo "::warning::update-branch failed (already up to date, conflict, or not permitted); not retrying"
+          else
+            echo "::notice::PR $PR_URL mergeStateStatus=$state failed=$failed; no self-heal needed"
+          fi
       - name: Checkout (for composite action resolution)
         if: failure()
         uses: actions/checkout@v6

--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -11,7 +11,7 @@ on:
     branches: [master, main]
     paths-ignore:
       - 'README.md'
-      - '.github/workflows/readme-gen.yml'
+      - '.github/workflows/20_readme-gen.yml'
 
 permissions:
   contents: write
@@ -23,7 +23,6 @@ concurrency:
 
 jobs:
   generate_readme:
-    if: github.repository != 'jclee941/.github'  # skip source repo
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     name: Generate README.md via CLIProxyAPI
     timeout-minutes: 10
@@ -58,7 +57,7 @@ jobs:
           CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
           OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
         run: |
-          set -e
+          set -eu
           python3 _bot-scripts/scripts/generate_readme.py --repo .
 
       - name: Check for changes
@@ -76,15 +75,8 @@ jobs:
       - name: Commit and push to branch
         if: steps.diff.outputs.changed == 'true'
         run: |
-          set -e
+          set -eu
           git config user.email "bot@jclee.me"
-          git config user.name "github-bot"
-          git checkout -b bot/auto-readme-update
-          git add README.md
-          git commit -m "docs: auto-update README.md [skip ci]"
-          gh auth setup-git
-          git push origin --delete bot/auto-readme-update || true
-          git push -u origin bot/auto-readme-update
           git config user.name "github-bot"
           git checkout -b bot/auto-readme-update
           git add README.md
@@ -97,7 +89,7 @@ jobs:
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
         run: |
-          set -e
+          set -eu
           existing=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" --title "docs: auto-update README.md" --body "Automated README.md update by jclee-bot."
@@ -114,7 +106,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true'
         run: |
-          set -e
+          set -eu
           pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           gh pr merge "$pr_number" --auto --squash
         env:

--- a/.github/workflows/24_release-notes.yml
+++ b/.github/workflows/24_release-notes.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - name: Harden Runner

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -35,10 +35,17 @@ jobs:
           repository: jclee941/.github
           path: .github-inventory
 
+      - name: Checkout local actions
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          fetch-depth: 1
+
       - name: Check latest workflow runs across all repos
         id: health
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -u
 
@@ -76,7 +83,8 @@ jobs:
       - name: Create or update health-check issue
         if: steps.health.outputs.failures_found == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          DETAILS: ${{ steps.health.outputs.details }}
         run: |
           set -u
 
@@ -89,7 +97,7 @@ jobs:
             echo ""
             echo "The following critical workflows have non-success conclusions in downstream repos:"
             echo ""
-            awk '/^details=<<EOF$/{p=1;next} /^EOF$/{p=0} p' "$GITHUB_OUTPUT"
+            printf '%s\n' "$DETAILS"
             echo ""
             echo "---"
             echo ""
@@ -118,7 +126,7 @@ jobs:
       - name: Close health-check issue if all green
         if: steps.health.outputs.failures_found == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -u
 
@@ -134,24 +142,4 @@ jobs:
           fi
       - name: Notify on failure
         if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -eu
-          SHORT_SHA="${GITHUB_SHA:0:8}"
-          TITLE="[ci-fail] $GITHUB_WORKFLOW @ $SHORT_SHA"
-          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-            --state open --label ci-failure \
-            --json number,title \
-            --jq ".[] | select(.title == \"$TITLE\") | .number" 2>/dev/null | head -1 || true)
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-              --body "Another failure: $RUN_URL" || true
-          else
-            gh label create ci-failure --color B60205 2>/dev/null || true
-            gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "$TITLE" \
-              --body "$GITHUB_WORKFLOW workflow failed on \`$GITHUB_SHA\`. See [run logs]($RUN_URL)." \
-              --label ci-failure || true
-          fi
+        uses: ./.github/actions/notify-on-failure

--- a/.github/workflows/43_reusable-issue-management.yml
+++ b/.github/workflows/43_reusable-issue-management.yml
@@ -131,6 +131,12 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
+      - name: Checkout local actions
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          fetch-depth: 1
       - name: Generate Issue Statistics
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/security/11_pr-review.yml
+++ b/.github/workflows/security/11_pr-review.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Check out base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -77,7 +77,7 @@ jobs:
           OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
           LITELLM_LOCAL_MODEL_COST_MAP: "True"
           CONFIG__MODEL: gpt-5.5
-          CONFIG__FALLBACK_MODELS: '["kimi-k2.5", "minimax-m2.7"]'
+          CONFIG__FALLBACK_MODELS: '["minimax-m2.7", "gpt-5.5"]'
           CONFIG__RESPONSE_LANGUAGE: ko
           CONFIG__AI_TIMEOUT: '300'
           CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
-/workflow runner conditional logic: private repos now use self-hosted runners, public repos use ubuntu-latest

- Self-heal mechanism: auto-update stale BLOCKED PRs when checks pass but merge is blocked (12/13 workflows)

- Fallback model chain updated: kimi models replaced with minimax-m2.7 and gpt-5.5 across PR review workflows

- Inline failure notification scripts replaced with reusable `.github/actions/notify-on-failure` action

- Action versions upgraded: harden-runner v2, checkout v6, upload-artifact v7, codeql-action v4

- README generator simplified: removed duplicate checkout/git commands and repository skip logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Files"] --> B["Runner Logic"]
  A --> C["Self-Heal Logic"]
  A --> D["Model Chain"]
  B --> B1["Private → self-hosted"]
  B --> B2["Public → ubuntu-latest"]
  C --> C1["BLOCKED PR detection"]
  C --> C2["update-branch API call"]
  D --> D1['kimi-k2.6 removed']
  D --> D2["minimax-m2.7 + gpt-5.5"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>CODEOWNERS</strong><dd><code>Update codeql and gitleaks workflow paths with prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>08_scorecard.yml</strong><dd><code>Upgrade action versions to versioned tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-3f8dd3c926ebcb070a478236f27005874644e69d024ddec128f338b9b07fb914">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>09_semantic-pr.yml</strong><dd><code>Add conditional runner based on repository visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-ac66605e9e7849a4fec25d59f3e6182aea0708876294a623a2807ad32828acc5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>10_pr-review.yml</strong><dd><code>Update model chain, add local actions checkout, use reusable notify </code><br><code>action</code></dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-e0248294e18c71b65ec8bd370fad557a9d6126473c7baca6a3df2dd574136be1">+14/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>20_readme-gen.yml</strong><dd><code>Remove repo skip, simplify git operations, fix path-ignore</code></dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+5/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>24_release-notes.yml</strong><dd><code>Add conditional runner based on repository visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-5bbdf91cb8caad94c80f48fc9dd239d77182e87810e0314037f39fd8cb56acbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>29_downstream-health-check.yml</strong><dd><code>Add local actions checkout, use GH_PAT, replace inline notify with </code><br><code>reusable action</code></dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+13/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>43_reusable-issue-management.yml</strong><dd><code>Add local actions checkout from jclee941/.github</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-57075a88baa77fc4d46f1579e284e6a9fc7b70634cfd3520edb0da93f9f6b5ad">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>11_pr-review.yml</strong><dd><code>Upgrade checkout to v6 and update fallback model chain</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-c75b1989a2e6809b6adb46fb2e03c008d1bd16935fdbb66ced9891b356a31bb1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>12_dependabot-auto-merge.yml</strong><dd><code>Add self-heal step for stale BLOCKED PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-003b699a8a6b0626cfe9d11302e4c6c58d7314211ef1b7a1c8f58738b0258b58">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>13_pr-auto-merge.yml</strong><dd><code>Add self-heal step for stale BLOCKED PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/186/files#diff-4e6c997fec11c213c0cd8b8ea0c14b64a9035ded963b007285e261d2aab0c435">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

