### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/13_pr-auto-merge.yml
+++ b/.github/workflows/13_pr-auto-merge.yml
@@ -119,8 +119,17 @@ jobs:
           fi
           # GitHub auto-merge only fires once all required status checks pass
           # and the merge box is green. We just enable it; we never bypass.
-          gh pr merge --auto --squash "$PR_URL" \
-            || echo "::warning::auto-merge enable failed (allow_auto_merge disabled, branch protection mismatch, or PR already merged); not retrying"
+          # Tolerate ONLY the "already merged/closed" race; surface every other
+          # failure (allow_auto_merge disabled, branch-protection mismatch) so
+          # the run does not silently report success on a broken automation.
+          if ! err=$(gh pr merge --auto --squash "$PR_URL" 2>&1); then
+            if printf '%s' "$err" | grep -qiE 'already merged|not mergeable: the merge commit cannot be created|pull request is closed|already been merged'; then
+              echo "::notice::auto-merge no-op: PR already merged/closed — $err"
+            else
+              echo "::error::auto-merge enable failed: $err"
+              exit 1
+            fi
+          fi
 
       - name: Self-heal stale BLOCKED PR
         # If checks pass but GitHub reports mergeStateStatus=BLOCKED, the PR's


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- PR 자동 병합 실패 시 침묵성공 방지

- 이미 병합/닫힌 PR 경쟁 조건은 무시

- 기타 오류 발생 시 워크플로우 실패 처리

- 오류 메시지 명시적 파싱으로 안정성 향상


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gh pr merge 실행"] --> B{"실패?"}
  B -- "아니오" --> C["정상 종료"]
  B -- "예" --> D{"이미 병합/닫힘?"}
  D -- "예" --> E["notice 로그 후 정상 종료"]
  D -- "아니오" --> F["error 로그 후 실패"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>13_pr-auto-merge.yml</strong><dd><code>PR 자동 병합 오류 처리 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/13_pr-auto-merge.yml

<ul><li><code>gh pr merge --auto --squash</code> 실행 시 발생한 오류를 <code>err</code> 변수에 캡처하여 명시적으로 검사하도록 변경<br> <li> <code>already merged</code>, <code>pull request is closed</code> 등의 경쟁 조건은 <code>::notice::</code>로 기록하고 <br>워크플로우를 성공으로 처리<br> <li> <code>allow_auto_merge</code> 비활성화, 브랜치 보호 불일치 등 기타 오류는 <code>::error::</code>로 기록하고 <code>exit 1</code>로 실패 <br>처리<br> <li> 기존 <code>|| echo "::warning::..."</code> 무조건 무시 패턴을 제거하여 자동화 문제를 숨기지 않음</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/safetywallet/pull/261/files#diff-4e6c997fec11c213c0cd8b8ea0c14b64a9035ded963b007285e261d2aab0c435">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

